### PR TITLE
Update IosAnalyticsDebugger.podspec

### DIFF
--- a/IosAnalyticsDebugger.podspec
+++ b/IosAnalyticsDebugger.podspec
@@ -22,9 +22,6 @@ Pod::Spec.new do |s|
   
   s.source_files = 'IosAnalyticsDebugger/Classes/**/*.{h,m}'
   
-  s.resources = ['IosAnalyticsDebugger/AvoAssets/*.xcassets',
-  'IosAnalyticsDebugger/Classes/**/*.xib']
-  
   s.resource_bundles = {
     'IosAnalyticsDebugger' => ['IosAnalyticsDebugger/AvoAssets/*.xcassets',
     'IosAnalyticsDebugger/Classes/**/*.xib']


### PR DESCRIPTION
Remove redundant Reouce declaration.

As per the cocoa pods spec, you can use either resources or resource_bundle, not both. 

But using either has some ups/downsides. As discussed in the threads below. This will have to be tested. But we cant seem to run the example project on our end to alidate this fix 

https://github.com/MessageKit/MessageKit/issues/1573 https://github.com/Azure/communication-ui-library-ios/issues/676